### PR TITLE
Use AREL for children and parent relationships

### DIFF
--- a/dagnabit.gemspec
+++ b/dagnabit.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = ["dagnabit-test"]
   s.require_paths = ["lib"]
 
-  s.add_dependency  'activerecord', ['>= 2.3.0', '< 3.1']
+  s.add_dependency  'activerecord', ['>= 2.3.0', '< 4']
 
   [
     [ 'ZenTest',    '~> 4.5.0' ],

--- a/dagnabit.gemspec
+++ b/dagnabit.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.name          = "dagnabit"
   s.version       = Dagnabit::VERSION
   s.platform      = Gem::Platform::RUBY
-  s.authors       = ["David Yip"]
-  s.email         = ["yipdw@member.fsf.org"]
+  s.authors       = ["David Yip", "Turadg Aleahmad"]
+  s.email         = ["yipdw@member.fsf.org", "turadg@geknowm.com"]
   s.homepage      = "http://rubygems.org/gems/dagnabit"
   s.summary       = %q{Directed acyclic graph plugin for ActiveRecord/PostgreSQL}
   s.description   = %q{Directed acyclic graph support library for applications using ActiveRecord on top of PostgreSQL.}
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = ["dagnabit-test"]
   s.require_paths = ["lib"]
 
-  s.add_dependency  'activerecord', ['>= 2.3.0', '< 4']
+  s.add_dependency  'activerecord', ['~> 3.0']
 
   [
     [ 'ZenTest',    '~> 4.5.0' ],

--- a/dagnabit.gemspec
+++ b/dagnabit.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = ["dagnabit-test"]
   s.require_paths = ["lib"]
 
-  s.add_dependency  'activerecord', ['~> 3.0']
+  s.add_dependency  'activerecord', ['> 3.0', '< 4.1']
 
   [
     [ 'ZenTest',    '~> 4.5.0' ],

--- a/lib/dagnabit/version.rb
+++ b/lib/dagnabit/version.rb
@@ -1,3 +1,3 @@
 module Dagnabit
-  VERSION = '3.1.1'
+  VERSION = '3.2.0-beta'
 end

--- a/lib/dagnabit/version.rb
+++ b/lib/dagnabit/version.rb
@@ -1,3 +1,3 @@
 module Dagnabit
-  VERSION = '3.2.0-beta'
+  VERSION = '3.2.0.beta'
 end

--- a/lib/dagnabit/version.rb
+++ b/lib/dagnabit/version.rb
@@ -1,3 +1,3 @@
 module Dagnabit
-  VERSION = '3.2.0.beta'
+  VERSION = '3.2.0.beta2'
 end

--- a/lib/dagnabit/vertex/associations.rb
+++ b/lib/dagnabit/vertex/associations.rb
@@ -8,10 +8,10 @@ module Dagnabit::Vertex
 
     ##
     # An override of {Settings#connected_by} that installs `has_many`
-    # associations named `parent_edges` and `child_edges` on a vertex model.
+    # associations named `edges_to_parents` and `edges_to_children` on a vertex model.
     #
-    # `parent_edges` is the collection of edges that flow _into_ a vertex;
-    # `child_edges` is the collection of edges that flow _out of_ a vertex.
+    # `edges_to_parents` is the collection of edges that flow _into_ a vertex;
+    # `edges_to_children` is the collection of edges that flow _out of_ a vertex.
     #
     # `parents` is the collection of vertices with edges that flow _into_ a vertex;
     # `children` is the collection of vertices with edges that flow _out of_ a vertex.
@@ -20,11 +20,11 @@ module Dagnabit::Vertex
     def connected_by(*args)
       super
 
-      has_many :parent_edges,  :class_name => edge_model_name, :foreign_key => 'child_id',  :dependent => :destroy
-      has_many :child_edges, :class_name => edge_model_name, :foreign_key => 'parent_id', :dependent => :destroy
+      has_many :edges_to_parents,  :class_name => edge_model_name, :foreign_key => 'child_id',  :dependent => :destroy
+      has_many :edges_to_children, :class_name => edge_model_name, :foreign_key => 'parent_id', :dependent => :destroy
 
-      has_many :parents,  :through => :parent_edges
-      has_many :children, :through => :child_edges
+      has_many :parents,  :through => :edges_to_parents
+      has_many :children, :through => :edges_to_children
 
     end
   end

--- a/lib/dagnabit/vertex/associations.rb
+++ b/lib/dagnabit/vertex/associations.rb
@@ -8,17 +8,24 @@ module Dagnabit::Vertex
 
     ##
     # An override of {Settings#connected_by} that installs `has_many`
-    # associations named `in_edges` and `out_edges` on a vertex model.
+    # associations named `parent_edges` and `child_edges` on a vertex model.
     #
-    # `in_edges` is the collection of edges that flow _into_ a vertex;
-    # `out_edges` is the collection of edges that flow _out of_ a vertex.
+    # `parent_edges` is the collection of edges that flow _into_ a vertex;
+    # `child_edges` is the collection of edges that flow _out of_ a vertex.
+    #
+    # `parents` is the collection of vertices with edges that flow _into_ a vertex;
+    # `children` is the collection of vertices with edges that flow _out of_ a vertex.
     #
     # @return [void]
     def connected_by(*args)
       super
 
-      has_many :in_edges,  :class_name => edge_model_name, :foreign_key => 'child_id',  :dependent => :destroy
-      has_many :out_edges, :class_name => edge_model_name, :foreign_key => 'parent_id', :dependent => :destroy
+      has_many :parent_edges,  :class_name => edge_model_name, :foreign_key => 'child_id',  :dependent => :destroy
+      has_many :child_edges, :class_name => edge_model_name, :foreign_key => 'parent_id', :dependent => :destroy
+
+      has_many :parents,  :through => :parent_edges
+      has_many :children, :through => :child_edges
+
     end
   end
 end

--- a/lib/dagnabit/vertex/neighbors.rb
+++ b/lib/dagnabit/vertex/neighbors.rb
@@ -24,22 +24,6 @@ module Dagnabit::Vertex
     end
 
     ##
-    # Finds all parents of the receiver object.
-    #
-    # @return [Array<ActiveRecord::Base>] a list of parent vertices
-    def parents
-      self.class.parents_of(self)
-    end
-
-    ##
-    # Finds all children of the receiver object.
-    #
-    # @return [Array<ActiveRecord::Base>] a list of child vertices
-    def children
-      self.class.children_of(self)
-    end
-
-    ##
     # Finds all descendants of the receiver object.
     #
     # @return [Array<ActiveRecord::Base>] a list of descendant vertices


### PR DESCRIPTION
I rolled my own DG but didn't have any cyclicity checks. I was happy to find this. But code like this stopped working:

  vertex.children << child_vertex

I saw that was because `children` and `parents` were written using queries instead of AREL. This commit bundle uses AREL for those, ups the minimum ActiveRecord to 3.x to get AREL, and bumps the version number to 3.2.0.beta.

Thoughts? btw, I tried running the tests but ran into problems with permission to drop language.
